### PR TITLE
Multi-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-canvas",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Knowledge is a tool for saving, searching, and chatting with all of your favorite websites, documents and files.",
   "author": "Rob Royce <robertris2@gmail.com> (https://robroyce.dev)",
   "license": "Apache-2.0",

--- a/src/kc_angular/src/app/app.module.ts
+++ b/src/kc_angular/src/app/app.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Rob Royce
+ * Copyright (c) 2022-2024 Rob Royce
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -162,6 +162,7 @@ import { SourceNotesComponent } from '@components/source-components/source.notes
 import { ProTipDirective } from './directives/pro-tip.directive';
 import { ProTipsComponent } from '@components/shared/pro-tips.component';
 import { ChatInputComponent } from '@components/chat-components/chat.input.component';
+import { WebImportComponent } from '@components/shared/web.import.component';
 
 @NgModule({
   declarations: [
@@ -240,6 +241,7 @@ import { ChatInputComponent } from '@components/chat-components/chat.input.compo
     SanitizeHtmlPipe,
     ProTipDirective,
     ProTipsComponent,
+    WebImportComponent,
   ],
   imports: [
     A11yModule,

--- a/src/kc_angular/src/app/components/shared/create.component.ts
+++ b/src/kc_angular/src/app/components/shared/create.component.ts
@@ -131,11 +131,7 @@ import { ConfirmationService } from 'primeng/api';
       </ng-template>
     </p-overlayPanel>
 
-    <p-dialog
-      #importDialog
-      header="Import Sources"
-      [(visible)]="showImportDialog"
-    >
+    <p-dialog #importDialog header="Web Import" [(visible)]="showImportDialog">
       <app-import-web (close)="showImportDialog = false"></app-import-web>
     </p-dialog>
   `,

--- a/src/kc_angular/src/app/components/shared/create.component.ts
+++ b/src/kc_angular/src/app/components/shared/create.component.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023 Rob Royce
+ * Copyright (c) 2022-2024 Rob Royce
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -77,18 +77,16 @@ import { ConfirmationService } from 'primeng/api';
         (change)="onNewFile($event)"
       />
       <button
-        #newFileButton
         pButton
         proTip
-        id="newFileButton"
         tipHeader="Web Surfer? Turn URLs into Sources"
         tipMessage="Got a cool web link? Turn it into a Source! Not only will Knowledge store the link for you to access anytime, but it'll also try to gather some handy metadata. Ready for some surfing?"
         [tipGroups]="['source', 'intro']"
         tipIcon="pi pi-link"
         [tipShowOnHover]="true"
         icon="pi pi-link"
-        class="newFileButton p-button-text outline-none shadow-none non-header"
-        (click)="createPanel.toggle($event)"
+        class="p-button-text outline-none shadow-none non-header"
+        (click)="showImportDialog = true"
       >
         +
       </button>
@@ -132,6 +130,14 @@ import { ConfirmationService } from 'primeng/api';
         </form>
       </ng-template>
     </p-overlayPanel>
+
+    <p-dialog
+      #importDialog
+      header="Import Sources"
+      [(visible)]="showImportDialog"
+    >
+      <app-import-web></app-import-web>
+    </p-dialog>
   `,
   styles: [],
 })
@@ -141,6 +147,8 @@ export class CreateComponent {
   linkForm: FormGroup;
 
   files: any[] = [];
+
+  showImportDialog = false;
 
   constructor(
     private dialog: DialogService,

--- a/src/kc_angular/src/app/components/shared/create.component.ts
+++ b/src/kc_angular/src/app/components/shared/create.component.ts
@@ -136,7 +136,7 @@ import { ConfirmationService } from 'primeng/api';
       header="Import Sources"
       [(visible)]="showImportDialog"
     >
-      <app-import-web></app-import-web>
+      <app-import-web (close)="showImportDialog = false"></app-import-web>
     </p-dialog>
   `,
   styles: [],

--- a/src/kc_angular/src/app/components/shared/web.import.component.ts
+++ b/src/kc_angular/src/app/components/shared/web.import.component.ts
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2024 Rob Royce
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Component, HostListener, ViewChild } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import {
+  KnowledgeSourceFactoryRequest,
+  KsFactoryService,
+} from '@services/factory-services/ks-factory.service';
+import { KnowledgeSource } from '@app/models/knowledge.source.model';
+import { KsCommandService } from '@services/command-services/ks-command.service';
+import { IngestService } from '@services/ingest-services/ingest.service';
+import { ProjectService } from '@services/factory-services/project.service';
+import { tap } from 'rxjs';
+
+@Component({
+  selector: 'app-import-web',
+  template: `
+    <form [formGroup]="linkForm">
+      <input
+        pInputText
+        #linkInput
+        id="linkInput"
+        formControlName="url"
+        required
+        [autofocus]="true"
+        class="border-0 mt-1 pb-3 mb-2"
+        type="url"
+        (keyup.enter)="onSubmit(linkInput.value)"
+        style="min-width: 35vw;"
+        placeholder="Enter a URL and press enter/return"
+      />
+    </form>
+
+    <div *ngIf="sources.length > 0" class="">
+      <div style="max-height: 50vh; overflow: overlay">
+        <p-table [value]="sources" [tableStyle]="{ 'min-width': '50rem' }">
+          <ng-template pTemplate="header">
+            <tr>
+              <th style="width: 32px"></th>
+              <th>Title</th>
+              <th style="width: 32px"></th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-source>
+            <tr>
+              <td>
+                <app-ks-icon [ks]="source"></app-ks-icon>
+              </td>
+              <td>
+                <!--                Input for users to edit the source title-->
+                <input
+                  pInputText
+                  [(ngModel)]="source.title"
+                  class="border-0"
+                  type="text"
+                  style="min-width: 20rem;"
+                  placeholder="source.title"
+                />
+              </td>
+              <td>
+                <app-action-bar
+                  [ks]="source"
+                  [showChat]="false"
+                  [showPreview]="true"
+                  [showEdit]="false"
+                  [showOpen]="true"
+                  [showSavePdf]="false"
+                  [showFlag]="true"
+                  [showRemove]="true"
+                  (flag)="addFlag(source)"
+                  (remove)="removeSource(source)"
+                  (open)="openSource(source)"
+                  (preview)="previewSource(source)"
+                >
+                </app-action-bar>
+              </td>
+            </tr>
+          </ng-template>
+        </p-table>
+      </div>
+
+      <div class="flex-row-center-between mt-6">
+        <p-selectButton
+          #destinationSelect
+          [options]="destinations"
+          [(ngModel)]="destination"
+          optionLabel="name"
+          class="w-9"
+        ></p-selectButton>
+        <button
+          pButton
+          label="Import"
+          class="p-button p-button-sm w-8rem"
+          (click)="import(destination.name)"
+        ></button>
+      </div>
+    </div>
+  `,
+})
+export class WebImportComponent {
+  // Handle for form input
+  @ViewChild('linkInput', { static: false }) linkInput: any;
+
+  linkForm: FormGroup;
+
+  sources: KnowledgeSource[] = [];
+
+  destinations: { name: string; code: string }[] = [
+    { name: 'Inbox', code: '1' },
+    { name: 'Project', code: '2' },
+  ];
+
+  destination: { name: string; code: string } = this.destinations[0];
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private factory: KsFactoryService,
+    private command: KsCommandService,
+    private ingest: IngestService,
+    private projects: ProjectService
+  ) {
+    this.linkForm = formBuilder.group({
+      url: ['', [Validators.required, Validators.pattern('https?://.+[.]+.+')]],
+    });
+
+    projects.currentProject
+      .pipe(
+        tap((project) => {
+          if (project) {
+            this.destinations = [
+              { name: 'Inbox', code: '1' },
+              { name: `Project (${project.name})`, code: '2' },
+            ];
+          }
+        })
+      )
+      .subscribe();
+  }
+
+  // HostListener for pasting text
+  @HostListener('paste', ['$event'])
+  onPaste(event: ClipboardEvent) {
+    const text = event.clipboardData?.getData('text');
+
+    // Get all URLs in text
+    const regex = /https?:\/\/[^\s]+/g;
+    const matches = text?.match(regex);
+
+    // Add URLs to array
+    if (matches) {
+      const urls: string[] = [];
+      matches.forEach((match) => {
+        // Remove commas from end of URLs
+        if (match.endsWith(',')) {
+          match = match.slice(0, -1);
+        }
+        urls.push(match);
+      });
+      this.createSource(urls);
+    }
+
+    // Clear form by resetting URL field, making sure the value is updated
+    setTimeout(() => {
+      this.linkForm.setValue({
+        url: '',
+      });
+      this.linkForm.reset();
+    });
+  }
+
+  onSubmit(value: string) {}
+
+  createSource(urls: string[]) {
+    const requests: KnowledgeSourceFactoryRequest = {
+      ingestType: 'website',
+      links: urls,
+    };
+
+    this.factory.many(requests).then((sources) => {
+      for (const source of sources) {
+        this.sources.push(source);
+      }
+    });
+  }
+
+  addFlag(source: KnowledgeSource) {
+    source.flagged = !source.flagged;
+  }
+
+  removeSource(source: KnowledgeSource) {
+    this.sources = this.sources.filter((s) => s !== source);
+  }
+
+  openSource(source: KnowledgeSource) {
+    this.command.open(source);
+  }
+
+  previewSource(source: KnowledgeSource) {
+    this.command.preview(source);
+  }
+
+  import(destination: string) {
+    console.log('Importing to ' + destination);
+
+    if (destination === 'Inbox') {
+      this.ingest.enqueue(this.sources);
+    } else {
+      // TODO: Implement project import
+    }
+
+    this.linkForm.reset();
+    this.sources = [];
+  }
+}

--- a/src/kc_angular/src/app/components/shared/web.import.component.ts
+++ b/src/kc_angular/src/app/components/shared/web.import.component.ts
@@ -14,7 +14,13 @@
  *  limitations under the License.
  */
 
-import { Component, HostListener, ViewChild } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import {
   KnowledgeSourceFactoryRequest,
@@ -25,6 +31,7 @@ import { KsCommandService } from '@services/command-services/ks-command.service'
 import { IngestService } from '@services/ingest-services/ingest.service';
 import { ProjectService } from '@services/factory-services/project.service';
 import { tap } from 'rxjs';
+import { ProjectUpdateRequest } from '@app/models/project.model';
 
 @Component({
   selector: 'app-import-web',
@@ -112,7 +119,8 @@ import { tap } from 'rxjs';
   `,
 })
 export class WebImportComponent {
-  // Handle for form input
+  @Output() close = new EventEmitter();
+
   @ViewChild('linkInput', { static: false }) linkInput: any;
 
   linkForm: FormGroup;
@@ -219,10 +227,18 @@ export class WebImportComponent {
     if (destination === 'Inbox') {
       this.ingest.enqueue(this.sources);
     } else {
-      // TODO: Implement project import
+      const project = this.projects.getCurrentProjectId();
+      if (project) {
+        const req: ProjectUpdateRequest = {
+          id: project,
+          addKnowledgeSource: this.sources,
+        };
+        this.projects.updateProjects([req]);
+      }
     }
 
     this.linkForm.reset();
     this.sources = [];
+    this.close.emit();
   }
 }

--- a/src/kc_angular/src/app/components/shared/web.import.component.ts
+++ b/src/kc_angular/src/app/components/shared/web.import.component.ts
@@ -48,13 +48,17 @@ import { ProjectUpdateRequest } from '@app/models/project.model';
         type="url"
         (keyup.enter)="onSubmit(linkInput.value)"
         style="min-width: 35vw;"
-        placeholder="Enter a URL and press enter/return"
+        placeholder="Enter a URL or a list of URLs and press enter/return..."
       />
     </form>
 
-    <div *ngIf="sources.length > 0" class="">
-      <div style="max-height: 50vh; overflow: overlay">
-        <p-table [value]="sources" [tableStyle]="{ 'min-width': '50rem' }">
+    <div class="">
+      <div style="height: 26rem; max-height: 26rem; overflow: overlay">
+        <p-table
+          *ngIf="sources.length > 0; else noSources"
+          [value]="sources"
+          [tableStyle]="{ 'min-width': '50rem' }"
+        >
           <ng-template pTemplate="header">
             <tr>
               <th style="width: 32px"></th>
@@ -98,6 +102,14 @@ import { ProjectUpdateRequest } from '@app/models/project.model';
             </tr>
           </ng-template>
         </p-table>
+
+        <ng-template #noSources>
+          <div class="flex-col-center-center h-full">
+            <div class="text-500">
+              <b>No Sources</b>
+            </div>
+          </div>
+        </ng-template>
       </div>
 
       <div class="flex-row-center-between mt-6">
@@ -112,6 +124,7 @@ import { ProjectUpdateRequest } from '@app/models/project.model';
           pButton
           label="Import"
           class="p-button p-button-sm w-8rem"
+          [disabled]="sources.length === 0"
           (click)="import(destination.name)"
         ></button>
       </div>

--- a/src/kc_angular/src/app/models/knowledge.source.model.ts
+++ b/src/kc_angular/src/app/models/knowledge.source.model.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Rob Royce
+ * Copyright (c) 2023-2024 Rob Royce
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -126,7 +126,7 @@ export class KnowledgeSourceNote {
   }
 
   static blank() {
-    return new KnowledgeSourceNote('test');
+    return new KnowledgeSourceNote('');
   }
 }
 

--- a/src/kc_angular/src/app/services/factory-services/ks-factory.service.ts
+++ b/src/kc_angular/src/app/services/factory-services/ks-factory.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Rob Royce
+ * Copyright (c) 2023-2024 Rob Royce
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -303,10 +303,25 @@ export class KsFactoryService {
     });
   }
 
+  private getLink(link: URL): string {
+    // If the link is a PDF file from arxiv.org, set the link to `https://arxiv.org/abs/${arxivId}` instead of the PDF link
+    if (
+      link.hostname === 'arxiv.org' &&
+      link.pathname.split('/')[1] === 'pdf'
+    ) {
+      const arxivId = link.pathname.split('/')[2];
+      if (arxivId) {
+        return `https://arxiv.org/abs/${arxivId}`;
+      }
+    }
+
+    // Otherwise, return the original link
+    return link.href;
+  }
+
   private getWebsiteMetadata(ks: KnowledgeSource): Promise<KnowledgeSource> {
     return new Promise<KnowledgeSource>((resolve) => {
-      const link =
-        typeof ks.accessLink === 'string' ? ks.accessLink : ks.accessLink.href;
+      const link = this.getLink(new URL(ks.accessLink));
       this.extractor
         .extractWebsiteMetadata(link)
         .then((metadata) => {

--- a/src/kc_angular/src/app/services/ingest-services/ingest.service.ts
+++ b/src/kc_angular/src/app/services/ingest-services/ingest.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Rob Royce
+ * Copyright (c) 2023-2024 Rob Royce
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -85,12 +85,17 @@ export class IngestService implements OnDestroy {
         this.notify.warn(
           'Ingest Service',
           'Ignoring Duplicate',
-          `Source: ${ks.title}`
+          `Source: ${ks.title}`,
+          'toast'
         );
         continue;
       }
 
       ksNext.push(ks);
+    }
+
+    if (ksNext.length <= 0) {
+      return;
     }
 
     ksQueue = ksQueue.concat(ksNext);

--- a/src/kc_angular/src/app/services/ingest-services/ingest.service.ts
+++ b/src/kc_angular/src/app/services/ingest-services/ingest.service.ts
@@ -108,7 +108,7 @@ export class IngestService implements OnDestroy {
     this.notify.success(
       'IngestService',
       'Source Imported',
-      `Imported ${ksList.length} Source${ksList.length > 1 ? 's' : ''}.`
+      `Imported ${ksNext.length} Source${ksNext.length > 1 ? 's' : ''}.`
     );
   }
 

--- a/src/kc_electron/src/local/controllers/chat.controller.ts
+++ b/src/kc_electron/src/local/controllers/chat.controller.ts
@@ -62,7 +62,10 @@ export default class ChatController {
 
   async summarize(text: string, succinct = true, verbose = false) {
     if (!(await this.veryifyApi()) || !this.openai) {
-      return text;
+      console.warn(
+        "[ChatController]: OpenAI API not initialized or unavailable, skipping summarization..."
+      );
+      return "";
     }
 
     const limited = this.tokenizerUtils.limitText.bind(this.tokenizerUtils);
@@ -118,6 +121,10 @@ export default class ChatController {
         const limitedChunksText = limitedChunks(text);
         let chunkedResponse = "";
 
+        console.log(
+          `[ChatController]: Limiting text to ${limitedChunksText.length} chunks...`
+        );
+
         for (let i = 0; i < limitedChunksText.length; i++) {
           // If the last message is a user message, remove it from the array
           // This is to ensure that each chunk is removed from the previous query
@@ -129,7 +136,7 @@ export default class ChatController {
 
           messages.push({
             role: "user",
-            content: `=========\n"""${chunk}"""\n=========`,
+            content: `===\n"""${chunk}"""\n===`,
           });
 
           // Sleep for 0.25 seconds to avoid rate limiting

--- a/src/kc_electron/src/local/middleware/DocumentSummarizer.ts
+++ b/src/kc_electron/src/local/middleware/DocumentSummarizer.ts
@@ -28,6 +28,9 @@ export class DocumentSummarizer {
     return async (req: Request, res: Response, next: NextFunction) => {
       // If the request already contains a summary, skip this middleware
       if (req.body.summary) {
+        console.log(
+          "[DocumentSummarizer]: Summary already exists, skipping DocumentSummarizer"
+        );
         return next();
       }
 


### PR DESCRIPTION
Upgrade the URL import functionality to support copy/pasting multiple URLs at a time. The new `Web Import` dialog displays the Sources and allows users to quickly edit Source titles, add flags, and choose between importing to Inbox or directly to the current project.

URLs can be separated by commas, newlines, or spaces.

<img width="771" alt="image" src="https://github.com/KnowledgeCanvas/knowledge/assets/19367848/a7f8eb1f-4b87-4d2a-80ac-ef6922b2fb91">
